### PR TITLE
refactor: Adaptar frontend a la separación de controladores del backend

### DIFF
--- a/src/Services/authService.ts
+++ b/src/Services/authService.ts
@@ -1,8 +1,12 @@
 // src/Services/authService.ts
 
 import axios from 'axios';
-import {jwtDecode} from 'jwt-decode'; // Importación correcta de jwt-decode
+import {jwtDecode} from 'jwt-decode'; 
 import Cookies from 'js-cookie';
+import { ChangePasswordDto } from '../types/Types';
+
+// URL base para tu API
+const BASE_URL = 'https://ctplamansion.onrender.com/api';
 
 // Define la estructura esperada del JWT decodificado
 interface DecodedUser {
@@ -12,11 +16,28 @@ interface DecodedUser {
   roles: string[];
 }
 
+// Crear una instancia de Axios para Auth
+const authClient = axios.create({
+  baseURL: BASE_URL,
+  headers: {
+    'Content-Type': 'application/json',
+  },
+});
+
+// Interceptor para agregar el token JWT a cada solicitud
+authClient.interceptors.request.use((config) => {
+  const token = Cookies.get('token');
+  if (token) {
+    config.headers.Authorization = `Bearer ${token}`;
+  }
+  return config;
+});
+
 // Realizar login y almacenar token en cookies
 export const login = async (email: string, password: string): Promise<DecodedUser | null> => {
   try {
-    const response = await axios.post(
-      'https://ctplamansion.onrender.com/api/User/login',
+    const response = await authClient.post(
+      '/Auth/login',
       { email, password },
       { headers: { 'Content-Type': 'application/json-patch+json' } }
     );
@@ -45,4 +66,77 @@ export const login = async (email: string, password: string): Promise<DecodedUse
 // Eliminar el token de las cookies al hacer logout
 export const logout = () => {
   Cookies.remove('token');
+};
+
+// Registrar un nuevo usuario
+export const register = async (userData: any): Promise<any> => {
+  try {
+    const response = await authClient.post('/Auth/register', userData);
+    return response.data;
+  } catch (error) {
+    console.error('Error al registrar usuario:', error);
+    throw error;
+  }
+};
+
+// Verificar email
+export const verifyEmail = async (userId: string, verificationCode: string): Promise<any> => {
+  try {
+    const response = await authClient.post(`/Auth/verify-email?userId=${userId}&verificationCode=${verificationCode}`);
+    return response.data;
+  } catch (error) {
+    console.error('Error al verificar email:', error);
+    throw error;
+  }
+};
+
+// Reenviar código de verificación
+export const resendVerificationCode = async (userId: string): Promise<any> => {
+  try {
+    const response = await authClient.post(`/Auth/resend-verification-code?userId=${userId}`);
+    return response.data;
+  } catch (error) {
+    console.error('Error al reenviar código de verificación:', error);
+    throw error;
+  }
+};
+
+// Enviar token para restablecer contraseña
+export const sendPasswordResetToken = async (email: string): Promise<any> => {
+  try {
+    const response = await authClient.post('/Auth/send-password-reset-token', JSON.stringify(email), {
+      headers: { 'Content-Type': 'application/json-patch+json' }
+    });
+    return response.data;
+  } catch (error) {
+    console.error('Error al enviar token para restablecer contraseña:', error);
+    throw error;
+  }
+};
+
+// Restablecer contraseña
+export const resetPassword = async (email: string, token: string, newPassword: string): Promise<any> => {
+  try {
+    const response = await authClient.post('/Auth/reset-password', {
+      email,
+      token,
+      newPassword
+    });
+    return response.data;
+  } catch (error) {
+    console.error('Error al restablecer contraseña:', error);
+    throw error;
+  }
+};
+
+// Cambio de contraseña
+export const changePassword = async (changePasswordDto: ChangePasswordDto): Promise<string> => {
+  try {
+    const response = await authClient.post('/Auth/change-password', changePasswordDto);
+    return response.data;
+  } catch (error: any) {
+    // Capturar mensaje de error específico del backend
+    const errorMessage = error.response?.data || 'Error al cambiar la contraseña';
+    throw new Error(errorMessage);
+  }
 };

--- a/src/Services/userService.ts
+++ b/src/Services/userService.ts
@@ -1,6 +1,5 @@
 import axios from 'axios';
-import Cookies from 'js-cookie'; // Importar js-cookie para manejar cookies
-import { ChangePasswordDto } from '../types/Types';
+import Cookies from 'js-cookie';
 
 // URL base para tu API
 const BASE_URL = 'https://ctplamansion.onrender.com/api';
@@ -93,18 +92,6 @@ export const updateUser = async (userId: number, updatedData: any): Promise<any>
   } catch (error) {
     console.error(`Error al actualizar los datos del usuario ${userId}:`, error);
     throw error;
-  }
-};
-
-// Cambio de contraseña
-export const changePassword = async (changePasswordDto: ChangePasswordDto): Promise<string> => {
-  try {
-    const response = await apiClient.post('/User/change-password', changePasswordDto);
-    return response.data;
-  } catch (error: any) {
-    // Capturar mensaje de error específico del backend
-    const errorMessage = error.response?.data || 'Error al cambiar la contraseña';
-    throw new Error(errorMessage);
   }
 };
 

--- a/src/components/RegisterForm.tsx
+++ b/src/components/RegisterForm.tsx
@@ -3,6 +3,7 @@ import { useForm } from "react-hook-form";
 import { useNavigate } from 'react-router-dom';
 import Modal from 'react-modal';
 import ImageUploader from './ImageUploader'; // Importar el componente ImageUploader
+import { register as registerUser } from "../services/authService"; // Importar la función de registro desde authService
 
 Modal.setAppElement('#root');
 
@@ -40,15 +41,8 @@ const RegisterForm: React.FC = () => {
       // Remove confirmPassword as it's not needed in the API request
       const { confirmPassword, ...dataToSend } = data;
 
-      const response = await fetch('https://ctplamansion.onrender.com/api/User/register', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(dataToSend),
-      });
-
-      if (!response.ok) throw new Error('Error en la solicitud');
-
-      const result = await response.json();
+      // Usar la función de registro desde authService
+      const result = await registerUser(dataToSend);
       const userId = result.id_User;
 
       if (userId) {

--- a/src/components/RequestPasswordReset.tsx
+++ b/src/components/RequestPasswordReset.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
-import axios from 'axios';
 import Modal from 'react-modal';
 import { useNavigate } from 'react-router-dom';
+import { sendPasswordResetToken } from '../services/authService';
 
 Modal.setAppElement('#root');
 
@@ -17,20 +17,10 @@ const RequestPasswordReset: React.FC = () => {
         e.preventDefault();
         setIsProcessing(true);
         try {
-            const response = await axios.post(
-                'https://ctplamansion.onrender.com/api/User/send-password-reset-token',
-                `"${email}"`,
-                { headers: { 'Content-Type': 'application/json-patch+json' } }
-            );
-
-            if (response.status === 200) {
-                setMessage('Se ha enviado un código de seguridad a su correo electrónico.');
-                setError(null);
-                setIsModalOpen(true);
-            } else {
-                setMessage(null);
-                setError('No se pudo enviar el código. Verifique su correo e inténtelo de nuevo.');
-            }
+            await sendPasswordResetToken(email);
+            setMessage('Se ha enviado un código de seguridad a su correo electrónico.');
+            setError(null);
+            setIsModalOpen(true);
         } catch (error) {
             setMessage(null);
             setError('Ocurrió un error al enviar el código. Por favor, inténtelo de nuevo.');
@@ -43,9 +33,10 @@ const RequestPasswordReset: React.FC = () => {
         setIsModalOpen(false);
         navigate('/reset-password');
     };
+    
     const handleGoBack = () => {
       navigate('/login');
-  };
+    };
 
     return (
         <div className="bg-white text-gray-800 flex justify-center items-center h-full">

--- a/src/components/ResetPasswordForm.tsx
+++ b/src/components/ResetPasswordForm.tsx
@@ -1,8 +1,8 @@
 import React, { useState } from 'react';
-import axios from 'axios';
 import Modal from 'react-modal';
 import { useNavigate } from 'react-router-dom';
 import { useTheme } from './ThemeContext';
+import { resetPassword } from '../services/authService';
 
 Modal.setAppElement('#root');
 
@@ -67,22 +67,10 @@ const ResetPasswordForm: React.FC = () => {
         }
 
         try {
-            const response = await axios.post('https://ctplamansion.onrender.com/api/User/reset-password', {
-                email,
-                token,
-                newPassword
-            }, {
-                headers: { 'Content-Type': 'application/json-patch+json' }
-            });
-
-            if (response.status === 200) {
-                setSuccessMessage('Su contraseña ha sido restablecida exitosamente.');
-                setErrorMessage(null);
-                setIsModalOpen(true);
-            } else {
-                setSuccessMessage(null);
-                setErrorMessage('No se pudo restablecer la contraseña.');
-            }
+            await resetPassword(email, token, newPassword);
+            setSuccessMessage('Su contraseña ha sido restablecida exitosamente.');
+            setErrorMessage(null);
+            setIsModalOpen(true);
         } catch (error) {
             setSuccessMessage(null);
             setErrorMessage('Ocurrió un error. Por favor, inténtelo de nuevo.');

--- a/src/components/VerificationForm.tsx
+++ b/src/components/VerificationForm.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
-import axios from 'axios';
 import { useNavigate } from 'react-router-dom';
+import { verifyEmail, resendVerificationCode } from '../services/authService';
 
 const VerificationForm = () => {
   const [verificationCode, setVerificationCode] = useState('');
@@ -18,16 +18,10 @@ const VerificationForm = () => {
     }
 
     try {
-      const response = await axios.post(`https://ctplamansion.onrender.com/api/User/verify-email?userId=${userId}&verificationCode=${verificationCode}`);
-
-      if (response.status === 200) {
-        setSuccess(true);
-        setError(null);
-        sessionStorage.removeItem('userId');
-      } else {
-        setError('La verificación falló. Por favor, inténtalo de nuevo.');
-        setSuccess(false);
-      }
+      await verifyEmail(userId, verificationCode);
+      setSuccess(true);
+      setError(null);
+      sessionStorage.removeItem('userId');
     } catch (error) {
       setError('Error al verificar el código. Por favor, inténtalo de nuevo.');
       setSuccess(false);
@@ -41,15 +35,9 @@ const VerificationForm = () => {
     }
 
     try {
-      const response = await axios.post(`https://localhost:7055/api/User/resend-verification-code?userId=${userId}`);
-
-      if (response.status === 200) {
-        setResendMessage('El código de verificación ha sido reenviado a tu correo electrónico.');
-        setError(null);
-      } else {
-        setResendMessage(null);
-        setError('No se pudo reenviar el código. Por favor, inténtalo de nuevo.');
-      }
+      await resendVerificationCode(userId);
+      setResendMessage('El código de verificación ha sido reenviado a tu correo electrónico.');
+      setError(null);
     } catch (error) {
       setResendMessage(null);
       setError('Error al reenviar el código. Por favor, inténtalo de nuevo.');

--- a/src/hooks/useUserProfile.ts
+++ b/src/hooks/useUserProfile.ts
@@ -3,10 +3,10 @@ import Cookies from 'js-cookie';
 import { 
   getUserById, 
   updateUser, 
-  changePassword, 
   getUserLabRequests, 
   getUserRoomRequests 
 } from '../services/userService';
+import { changePassword } from '../services/authService';
 import { ChangePasswordDto } from '../types/Types';
 
 export const useUserProfile = (userId: number | undefined) => {


### PR DESCRIPTION
- Dividir la lógica de autenticación de userService a un authService dedicado
- Actualizar authService para apuntar a los nuevos endpoints /api/Auth
- Mantener userService enfocado en operaciones CRUD con endpoints /api/User
- Actualizar componentes para usar los servicios refactorizados:
  - RegisterForm
  - VerificationForm
  - RequestPasswordReset
  - ResetPasswordForm
- Actualizar hook useUserProfile para importar changePassword desde authService

Estos cambios se alinean con la refactorización del backend donde UserController se dividió en UserController y AuthController para mejorar la separación de responsabilidades.